### PR TITLE
Fix benchmarks for fastexp

### DIFF
--- a/fastexp.go
+++ b/fastexp.go
@@ -67,7 +67,7 @@ func FastExp3(x float32) float32 {
 
 // FastExp is a quartic spline approximation to the Exp function, by N.N. Schraudolph
 // It does not have any of the sanity checking of a standard method -- returns
-// nonsense when arg is out of range.  Runs in .24ns vs. 8.7ns for 64bit which is faster
+// nonsense when arg is out of range.  Runs in 3.48ns vs. 8.8ns for 64bit which is faster
 // than math32.Exp actually.
 func FastExp(x float32) float32 {
 	if x <= -88.76731 { // this doesn't add anything and -exp is main use-case anyway

--- a/fastexp_test.go
+++ b/fastexp_test.go
@@ -20,22 +20,30 @@ func TestFastExp(t *testing.T) {
 	}
 }
 
+var result32 float32
 func BenchmarkFastExp(b *testing.B) {
+	var x float32
 	for n := 0; n < b.N; n++ {
-		FastExp(float32(n%40 - 20))
+		x = FastExp(float32(n%40 - 20))
 	}
+	result32 = x
 }
 
+var result64 float64
 func BenchmarkExpStd64(b *testing.B) {
+	var x float64
 	for n := 0; n < b.N; n++ {
-		math.Exp(float64(n%40 - 20))
+		x = math.Exp(float64(n%40 - 20))
 	}
+	result64 = x
 }
 
 /*
 func BenchmarkExp32(b *testing.B) {
+	var x float32
 	for n := 0; n < b.N; n++ {
-		math32.Exp(float32(n%40 - 20))
+		x = math32.Exp(float32(n%40 - 20))
 	}
+	result32 = x
 }
 */


### PR DESCRIPTION
The benchmark for `fastexp` has a bug I believe, where the compiler is removing the code to be benchmarked.  Here's a link to [Godbolt](https://go.godbolt.org/#z:OYLghAFBqd5TB8IAsQGMD2ATApgUWwEsAXTAJwBoiQIAzIgG1wDsBDAW1xAHIBGHpTqYWJAMro2zEHwAsQkSQCqAZ1wAFAB68ADIIBWMyozYtQwTJTXN0JIiNqtsAYUyMArhxYyArJScAMkQsuAByngBGuOQgAEw6lAAOmCqk9iyuHl6%2BSSlpIkEh4RxRMfFWuDZ2ImIkbOQkmZ7efH7WuLbptfUkhWGR0XEJKnUNTdmtVqO9wf0lg/EAlFaY7uTo3DyJbOgA1mzAuADUHGzBAKQ6AIKXV0QcyQ1HELdHb0fnsbGnJCifsa93v8SLgRsFgP9botbrc6O4WOgjgAxNgjfCaRIQTRHOiMTBsEgAZliixxeIJxI%2BAHYAEIwnQATiIdCO2POhOc7IAIkcALQADn5ADoqQA2KmEvjUmlHAD0sqOvyIKiO2EwoJYYB4JCObGw2F1LAAnkqzIaDbzcBijsqTmcWEd3GpeZI1IajQB3NhG%2BkMy4M8i4EhrB06X3nKlc31EI4gbk20TEiB8WJ8HRfHSEgBUmlJnxlKapWeT7M5HNihOh139HFj8Zj7PwjaOVI%2BsVFRx0miRPaRcoVWESRrtomVKjY0bbdMJPKgc/nUEJPkJrazJzzhKbm6OfFFediBcJotF/NJa44G63%2BB3p6nO58/L4VLP64%2Bm%2BbclJvKO/J0sipOgvheb5XjufBVjcjKBsG5AOj8KBCki5JErEdDkJgJSkCoEDuMEKEQEQiwQRGUbVtcABu9RHIGKjuIwKFkviKGwvCiI0qw6AoKc5C7CiaIYhAERHFmIJgmYQo0nmtK%2BpR5CsoxFIAmRDLCHJDpxjOnbsjKDqlkcERCqE2lHCw%2Bb5tK4aMmyml8SQ6KYriTFJqZsQ%2BLIOh8kcSzEYyJG%2BjRdEMfGmgwpG9JXHCCJ2sEEBSXSkY8MsjC8D4gjeDweiUJgvAAOKYEcKirOsxyfJKggkLoiXLLsIA%2BAkyU8LIggcCAhKEkKbWdV13WUOlmXZTwggqCACQVRliWUHAsBoFgDxMNE1C0LNiTzTEwCMHwfAMgkeDkUQGwAGpELgHoAPKJKwvACEITAguQw2CZVlARME9RGldgizVwoinSwjDveNlB4KcZjSIDxCBp05Ggk9VodO4IIfdQoiVE9jBEBE5Bva4eBPSQ5D3B9yy4gcKhHSd52XfwgjCKIEhSNwcgKKIqgaNogOGHwximOYljoxEw2QMsmCJNULDDYNKxrBsMhJSlaVPQNuocNgoqyEcwCInwQpbc8hCkBQbaSos5WVURlAoLgeqDLFlA1XVxi8E1vWK7wQ0jZQY16ObDWxM1ICyAyQoMiHodh2HLuAwNpvjcsU1INNGA4AQxBkFQND0PN7BcEjtPiJI0hM3nrNaE9hixNzZggBYFRVOkjgsC4bjNDkgSzMUpRxFSuSpGL4wtH4yS9%2BkfQdws3ftJ0NTTP3OST2L3QNKPAxlBPM/NxMbTTMv8yr8shXS5s2x7AcxynBcZF3A8FA6i81zvG23wEn8XyAm8wKgnYZiQtcPkRaxyJUR2QEtiRyilSRgKCtJZSzJ5KlnjAKYUYoJRSgjDKeUioUC2jVBqLUOo9QGlMCaLBZpTAWitIkG0Kpz4OidLgF0qJjhEK9D6ZS/poIhi0mwsKMC6yaTwkmFMaYMzZlzHeQsxY%2BDwPLJWX0tYNI8gbO%2BbcrZPgdi7L2PsGDBzDhBnYFQ45JxmU0guUxS4VzCVfI2D8e5xFHhPEBS8H5bzmVaI%2BZ8ljgLWO3J%2BTyv5/yAU8U4nx4F/JBk4fBRCyFiRoQwi9Eg2FcKJliARIioVSKQSuLJaioJAqUkgcSFiUV2IIi4vUXiQD7KCWEqJL%2BwAJJxRklRUB0SlKQRUobdS8YwyEh0m%2BZw%2BlDLGRcnSA8Fk2GMlslUgpKSXJuQ8t%2Bby4YeHtICvRSkwV0nhUioiGhsULIJTljwVKkd%2Bq5XygfYqRs/aezNtVWq9Unb%2B0DsHcObyQ6nMENHKwHsvYTXjqgJOc1mDpyWhhFaILq4bS2jtXAe1DrHTOhddK10GD0WiA9CIT0XrsHIADa6X1WAkF%2Bv9J6wMeZg0yhDDodhoYS0ynDdACNNjXTwqjQG/MsZ4pxpsTK%2BNCbU2JiYYAZNEWUxRTTRQ9NC7yGLmoUuHM4iV15sYDGgtbYizFhLIaRUZYkkdschWUdeDK1VurTWO4dYMj1qnQ2pUSQx29ssS21sYi23to8xqRqzmS2GqNO5BqbktRee895nyspu1ubHe5DsGqEm9V8yNfy46IEBcQOgdBFr0ClQXRmsrFAl3ZplRgKBhpcxLSodNdASBGguh7cgpalUNsrcyattbuCAQNScvqiaeBclbUccmHpoimrVhrLWVqjjkRVJwM147LVbUdVVO2DyDXOx7RG31vyA2%2BwTZupd5tob3XrrIIAA) showing how the assembly for actually calling the `fastexp` function is not present in the current version of the benchmark. Left side shows the 2 source codes (once with `x=...`, once without), right side the assembly diff.

The benchmark now correctly reports `fastexp` taking 4ns (compared to math.exp taking 8ns). I looked at this since the benchmark in it's current form reports 0.3ns / Op, which would mean my ~3GHz CPU retires one Exp OP per cycle, which seemed way too fast to me.