### PR TITLE
try to find a cutoff point for NaNs

### DIFF
--- a/fastexp.go
+++ b/fastexp.go
@@ -72,7 +72,7 @@ func FastExp3(x float32) float32 {
 // nonsense when arg is out of range.  Runs in 2.23ns vs. 6.3ns for 64bit which is faster
 // than math32.Exp actually.
 func FastExp(x float32) float32 {
-	if x <= -88.76731 { // this doesn't add anything and -exp is main use-case anyway
+	if x <= -88.029701 { // this doesn't add anything and -exp is main use-case anyway
 		return 0
 	}
 	i := int32(12102203*x) + 127*(1<<23)

--- a/fastexp_test.go
+++ b/fastexp_test.go
@@ -54,9 +54,8 @@ func TestFastExpFindNaN(t *testing.T) {
 		if cnt%10000 == 0 {
 			fmt.Printf("Trying x: %f\n", x)
 		}
-		x2 := x
 		// make sure you comment out the cutoff point in FastExp first
-		fx := FastExp(x2)
+		fx := FastExp(x)
 		if math.IsNaN(float64(fx)) {
 			t.Errorf("Found NaN at x=%f", x)
 			left = x

--- a/fastexp_test.go
+++ b/fastexp_test.go
@@ -20,6 +20,54 @@ func TestFastExp(t *testing.T) {
 	}
 }
 
+func TestFastExpNaN(t *testing.T) {
+	// found this in boa function EncodeVal of PopCodeParams
+	x := float32(9.398623)
+	x2 := -(x * x) // should be 88.33411429612902
+	fx := FastExp(x2)
+	if math.IsNaN(float64(fx)) {
+		t.Fatalf("Found NaN at x=%g fx=%g", x2, fx)
+	}
+}
+
+func TestFastExpNaNRange(t *testing.T) {
+	cnt := 0
+	for x := float32(-89); x <= -87; x += 1.0e-03 {
+		cnt++
+		if cnt%10000 == 0 {
+			fmt.Printf("Trying x: %f\n", x)
+		}
+		x2 := x
+		fx := FastExp(x2)
+		if math.IsNaN(float64(fx)) {
+			t.Fatalf("Found NaN at x=%f", x)
+		}
+	}
+	fmt.Printf("cnt: %v\n", cnt)
+}
+
+func TestFastExpFindNaN(t *testing.T) {
+	// use binary search to find the NaN cutoff point
+	left := float32(-89)
+	right := float32(-87)
+	x := float32(0)
+	for cnt := 0; cnt < 100000; cnt++ {
+		x = (left + right) / 2
+		if cnt%1000 == 0 {
+			fmt.Printf("Trying x: %f\n", x)
+		}
+		x2 := x
+		// make sure you comment out the cutoff point in FastExp first
+		fx := FastExp(x2)
+		if math.IsNaN(float64(fx)) {
+			t.Errorf("Found NaN at x=%f", x)
+			left = x
+		} else {
+			right = x
+		}
+	}
+}
+
 var result32 float32
 
 func BenchmarkFastExp(b *testing.B) {

--- a/fastexp_test.go
+++ b/fastexp_test.go
@@ -34,16 +34,14 @@ func TestFastExpNaNRange(t *testing.T) {
 	cnt := 0
 	for x := float32(-89); x <= -87; x += 1.0e-03 {
 		cnt++
-		if cnt%10000 == 0 {
+		if cnt%1000 == 0 {
 			fmt.Printf("Trying x: %f\n", x)
 		}
-		x2 := x
-		fx := FastExp(x2)
+		fx := FastExp(x)
 		if math.IsNaN(float64(fx)) {
 			t.Fatalf("Found NaN at x=%f", x)
 		}
 	}
-	fmt.Printf("cnt: %v\n", cnt)
 }
 
 func TestFastExpFindNaN(t *testing.T) {
@@ -53,7 +51,7 @@ func TestFastExpFindNaN(t *testing.T) {
 	x := float32(0)
 	for cnt := 0; cnt < 100000; cnt++ {
 		x = (left + right) / 2
-		if cnt%1000 == 0 {
+		if cnt%10000 == 0 {
 			fmt.Printf("Trying x: %f\n", x)
 		}
 		x2 := x


### PR DESCRIPTION
I discovered this NaN bug while chasing down a boa bug where a drive was set to a tiny value and the popcoder tried to use the FastExp function on a value derived from it.

I used binary search to find a good cutoff value for when things turn to NaN. I don't know if it's correct to use binary search here but it makes sense no?

